### PR TITLE
Coremem cleanup

### DIFF
--- a/verilog/coremem.sv
+++ b/verilog/coremem.sv
@@ -32,7 +32,7 @@ module coremem
    logic        ar_valid_o;
    logic        r_valid_i;
 
-   enum         logic [2:0] { IDLE, READ_WAIT, WRITE_WAIT } CS, NS;
+   enum         logic [2:0] { IDLE, READ_WAIT, WRITE_DATA, WRITE_ADDR, WRITE_WAIT } CS, NS;
 
    assign CE = aw_valid_o | ar_valid_o;
    assign WE = aw_valid_o;

--- a/verilog/coremem.sv
+++ b/verilog/coremem.sv
@@ -25,15 +25,12 @@ module coremem
    input logic  data_we_i,
    output logic CE, WE
    );
-   
+
    logic        aw_valid_o;
-   logic        aw_ready_i;
    logic        w_valid_o;
-   logic        w_ready_i;
    logic        b_valid_i;
    logic        b_ready_o;
    logic        ar_valid_o;
-   logic        ar_ready_i;
    logic        r_valid_i;
    logic        r_ready_o;
 
@@ -41,10 +38,7 @@ module coremem
 
    assign CE = aw_valid_o | ar_valid_o;
    assign WE = aw_valid_o;
-   assign aw_ready_i = 1'b1;
-   assign ar_ready_i = 1'b1;
-   assign w_ready_i = 1'b1;
-   
+
    // main FSM
    always_comb
      begin
@@ -72,29 +66,13 @@ module coremem
                        aw_valid_o = 1'b1;
                        w_valid_o  = 1'b1;
 
-                       if (aw_ready_i) begin
-                          if (w_ready_i) begin
-                             data_gnt_o = 1'b1;
-                             NS = WRITE_WAIT;
-                          end else begin
-                             NS = WRITE_DATA;
-                          end
-                       end else begin
-                          if (w_ready_i) begin
-                             NS = WRITE_ADDR;
-                          end else begin
-                             NS = IDLE;
-                          end
-                       end
+                       data_gnt_o = 1'b1;
+                       NS = WRITE_WAIT;
                     end else begin
                        ar_valid_o = 1'b1;
 
-                       if (ar_ready_i) begin
-                          data_gnt_o = 1'b1;
-                          NS = READ_WAIT;
-                       end else begin
-                          NS = IDLE;
-                       end
+                       data_gnt_o = 1'b1;
+                       NS = READ_WAIT;
                     end
                end else begin
                   NS = IDLE;
@@ -105,10 +83,9 @@ module coremem
           // accepted the address already
           WRITE_DATA: begin
              w_valid_o = 1'b1;
-             if (w_ready_i) begin
-                data_gnt_o = 1'b1;
-                NS = WRITE_WAIT;
-             end
+
+             data_gnt_o = 1'b1;
+             NS = WRITE_WAIT;
           end
 
           // the bus has accepted the write data, but not yet the address
@@ -117,10 +94,8 @@ module coremem
           WRITE_ADDR: begin
              aw_valid_o = 1'b1;
 
-             if (aw_ready_i) begin
-                data_gnt_o = 1'b1;
-                NS = WRITE_WAIT;
-             end
+             data_gnt_o = 1'b1;
+             NS = WRITE_WAIT;
           end
 
           // we have sent the address and data and just wait for the write data to

--- a/verilog/coremem.sv
+++ b/verilog/coremem.sv
@@ -34,7 +34,7 @@ module coremem
    logic        r_valid_i;
    logic        r_ready_o;
 
-   enum         logic [2:0] { IDLE, READ_WAIT, WRITE_DATA, WRITE_ADDR, WRITE_WAIT } CS, NS;
+   enum         logic [2:0] { IDLE, READ_WAIT, WRITE_WAIT } CS, NS;
 
    assign CE = aw_valid_o | ar_valid_o;
    assign WE = aw_valid_o;
@@ -77,25 +77,6 @@ module coremem
                end else begin
                   NS = IDLE;
                end
-          end
-
-          // if the bus has not accepted our write data right away, but has
-          // accepted the address already
-          WRITE_DATA: begin
-             w_valid_o = 1'b1;
-
-             data_gnt_o = 1'b1;
-             NS = WRITE_WAIT;
-          end
-
-          // the bus has accepted the write data, but not yet the address
-          // this happens very seldom, but we still have to deal with the
-          // situation
-          WRITE_ADDR: begin
-             aw_valid_o = 1'b1;
-
-             data_gnt_o = 1'b1;
-             NS = WRITE_WAIT;
           end
 
           // we have sent the address and data and just wait for the write data to

--- a/verilog/minion_soc.sv
+++ b/verilog/minion_soc.sv
@@ -45,7 +45,7 @@ module minion_soc
  //keyboard
  inout wire PS2_CLK,
  inout wire PS2_DATA,
- 
+
    // display
  output wire           VGA_HS_O,
  output wire           VGA_VS_O,
@@ -53,18 +53,18 @@ module minion_soc
  output wire  [3:0]    VGA_BLUE_O,
  output wire  [3:0]    VGA_GREEN_O
  );
- 
+
  wire [19:0] dummy;
  wire        irst, ascii_ready;
  wire [7:0]  readch, scancode;
- wire        keyb_almostfull, keyb_full, keyb_rderr, keyb_wrerr, keyb_empty;   
+ wire        keyb_almostfull, keyb_full, keyb_rderr, keyb_wrerr, keyb_empty;
  wire [11:0] keyb_wrcount, keyb_rdcount;
  reg [31:0]  keycode;
  wire [31:0] keyb_fifo_status = {keyb_empty,keyb_almostfull,keyb_full,keyb_rderr,keyb_wrerr,keyb_rdcount,keyb_wrcount};
  wire [35:0] keyb_fifo_out;
- 
+
   assign one_hot_rdata[9] = core_lsu_addr[2] ? {keyb_empty,keyb_fifo_out[15:0]} : keyb_fifo_status;
- 
+
     ps2 keyb_mouse(
       .clk(msoc_clk),
       .rst(irst),
@@ -76,14 +76,14 @@ module minion_soc
       .ascii_data_ready(ascii_ready),
       .rx_translated_scan_code(scancode),
       .rx_ascii_read(ascii_ready));
- 
+
  my_fifo #(.width(36)) keyb_fifo (
        .rd_clk(~msoc_clk),      // input wire read clk
        .wr_clk(~msoc_clk),      // input wire write clk
        .rst(~rstn),      // input wire rst
        .din({19'b0, readch[6:0], scancode}),      // input wire [31 : 0] din
        .wr_en(ascii_ready),  // input wire wr_en
-       .rd_en(core_lsu_req&core_lsu_we&one_hot_data_addr[9]),  // input wire rd_en
+       .rd_en(we_d&one_hot_data_addr[9]),  // input wire rd_en
        .dout(keyb_fifo_out),    // output wire [31 : 0] dout
        .rdcount(keyb_rdcount),         // 12-bit output: Read count
        .rderr(keyb_rderr),             // 1-bit output: Read error
@@ -93,9 +93,9 @@ module minion_soc
        .full(keyb_full),    // output wire full
        .empty(keyb_empty)  // output wire empty
      );
-    
+
     wire [7:0] red,  green, blue;
- 
+
     fstore2 the_fstore(
       .pixel2_clk(pxl_clk),
       .blank(),
@@ -121,9 +121,9 @@ module minion_soc
       .GPIO_SW_N(GPIO_SW_N),
       .GPIO_SW_S(GPIO_SW_S),
       .GPIO_SW_E(GPIO_SW_E),
-      .GPIO_SW_W(GPIO_SW_W)              
+      .GPIO_SW_W(GPIO_SW_W)
      );
- 
+
  assign VGA_RED_O = red[7:4];
  assign VGA_GREEN_O = green[7:4];
  assign VGA_BLUE_O = blue[7:4];
@@ -163,7 +163,7 @@ logic [31:0]  core_lsu_rdata;
   logic [31:0] one_hot_rdata[15:0];
 
   assign shared_sel = one_hot_data_addr[8];
-   
+
 always_comb
   begin:onehot
      integer i;
@@ -294,19 +294,19 @@ progmem block_i (
   /// APB Slave 0: APB UART interface                            ///
   ///                                                            ///
   //////////////////////////////////////////////////////////////////
-	     
+
 reg u_trans;
 reg u_recv;
 reg [15:0] u_baud;
 wire received, recv_err, is_recv, is_trans, uart_maj;
-wire uart_almostfull, uart_full, uart_rderr, uart_wrerr, uart_empty;   
+wire uart_almostfull, uart_full, uart_rderr, uart_wrerr, uart_empty;
 wire [11:0] uart_wrcount, uart_rdcount;
 wire [8:0] uart_fifo_data_out;
 reg  [7:0] u_tx_byte;
 
 rx_delay uart_rx_dly(
 .clk(msoc_clk),
-.in(uart_rx),		     
+.in(uart_rx),
 .maj(uart_maj));
 
 uart i_uart(
@@ -332,14 +332,14 @@ assign one_hot_rdata[3] = {uart_wrcount,uart_almostfull,uart_full,uart_rderr,uar
    wire       sd_data_busy, data_crc_ok, sd_dat_oe;
    wire [3:0] sd_dat_to_mem, sd_dat_to_host, sd_dat_to_host_maj;
    wire       sd_cmd_to_mem, sd_cmd_to_host, sd_cmd_to_host_maj, sd_cmd_oe;
-   wire       sd_clk_o;       
+   wire       sd_clk_o;
    wire       sd_cmd_finish, sd_data_finish, sd_cmd_crc_ok, sd_cmd_index_ok;
 
    reg [2:0]  sd_data_start_reg;
    reg [1:0]  sd_align_reg;
    reg [15:0] sd_blkcnt_reg;
    reg [11:0] sd_blksize_reg;
-   
+
    reg [15:0] clock_divider_sd_clk_reg;
    reg [2:0]  sd_cmd_setting_reg;
    reg [5:0]  sd_cmd_i_reg;
@@ -352,7 +352,7 @@ assign one_hot_rdata[3] = {uart_wrcount,uart_almostfull,uart_full,uart_rderr,uar
    reg [1:0]  sd_align;
    reg [15:0] sd_blkcnt;
    reg [11:0] sd_blksize;
-   
+
    reg [15:0] clock_divider_sd_clk;
    reg [2:0]  sd_cmd_setting;
    reg [5:0]  sd_cmd_i;
@@ -401,7 +401,7 @@ always @(posedge msoc_clk or negedge rstn)
     from_dip_reg <= from_dip;
 	u_recv <= received;
 	core_lsu_addr_dly <= core_lsu_addr;
-	if (core_lsu_req&core_lsu_we&one_hot_data_addr[6])
+	if (we_d&one_hot_data_addr[6])
 	  case(core_lsu_addr[5:2])
 	    0: sd_align_reg <= core_lsu_wdata;
 	    1: sd_clk_din <= core_lsu_wdata;
@@ -415,10 +415,10 @@ always @(posedge msoc_clk or negedge rstn)
 	    9: sd_cmd_timeout_reg <= core_lsu_wdata;
 	   10: {sd_clk_dwe,sd_clk_den,sd_clk_daddr} <= core_lsu_wdata;
 	  endcase
-	if (core_lsu_req&core_lsu_we&one_hot_data_addr[7])
+	if (we_d&one_hot_data_addr[7])
 	  to_led <= core_lsu_wdata;
 	u_trans <= 1'b0;
-    if (core_lsu_req&core_lsu_we&one_hot_data_addr[2])
+    if (we_d&one_hot_data_addr[2])
       case(core_lsu_addr[5:2])
         0: begin u_trans <= 1'b1; u_tx_byte <= core_lsu_wdata[7:0]; end
         1: u_baud <= core_lsu_wdata;
@@ -436,14 +436,14 @@ always @(posedge sd_clk_o)
 	sd_blksize <= sd_blksize_reg;
 	sd_cmd_timeout <= sd_cmd_timeout_reg;
     end
-    
+
 my_fifo #(.width(9)) uart_rx_fifo (
   .rd_clk(~msoc_clk),      // input wire read clk
   .wr_clk(~msoc_clk),      // input wire write clk
   .rst(~rstn),      // input wire rst
   .din({recv_err,core_lsu_rx_byte}),      // input wire [width-1 : 0] din
   .wr_en(received&&!u_recv),  // input wire wr_en
-  .rd_en(core_lsu_req&core_lsu_we&one_hot_data_addr[3]),  // input wire rd_en
+  .rd_en(we_d&one_hot_data_addr[3]),  // input wire rd_en
   .dout(uart_fifo_data_out),    // output wire [width-1 : 0] dout
   .rdcount(uart_rdcount),         // 12-bit output: Read count
   .rderr(uart_rderr),             // 1-bit output: Read error
@@ -456,21 +456,21 @@ my_fifo #(.width(9)) uart_rx_fifo (
 
    //Tx Fifo
    wire [31:0] data_in_rx_fifo;
-   wire        tx_almostfull, tx_full, tx_rderr, tx_wrerr, tx_empty;   
+   wire        tx_almostfull, tx_full, tx_rderr, tx_wrerr, tx_empty;
    wire [11:0] tx_wrcount, tx_rdcount;
    //Rx Fifo
    wire [31:0] data_out_tx_fifo;
-   wire        rx_almostfull, rx_full, rx_rderr, rx_wrerr, rx_empty;   
+   wire        rx_almostfull, rx_full, rx_rderr, rx_wrerr, rx_empty;
    wire [11:0] rx_wrcount, rx_rdcount;
    wire data_rst = ~(sd_data_rst&rstn);
-   
+
    parameter iostd = "LVTTL";
    parameter slew = "FAST";
    parameter iodrv = 24;
    // tri-state gate
    IOBUF #(
        .DRIVE(iodrv), // Specify the output drive strength
-       .IBUF_LOW_PWR("FALSE"),  // Low Power - "TRUE", High Performance = "FALSE" 
+       .IBUF_LOW_PWR("FALSE"),  // Low Power - "TRUE", High Performance = "FALSE"
        .IOSTANDARD(iostd), // Specify the I/O standard
        .SLEW(slew) // Specify the output slew rate
     ) IOBUF_cmd_inst (
@@ -482,12 +482,12 @@ my_fifo #(.width(9)) uart_rx_fifo (
 
     rx_delay cmd_rx_dly(
         .clk(clk_200MHz),
-        .in(sd_cmd_to_host),             
+        .in(sd_cmd_to_host),
         .maj(sd_cmd_to_host_maj));
 
    IOBUF #(
         .DRIVE(iodrv), // Specify the output drive strength
-        .IBUF_LOW_PWR("FALSE"),  // Low Power - "TRUE", High Performance = "FALSE" 
+        .IBUF_LOW_PWR("FALSE"),  // Low Power - "TRUE", High Performance = "FALSE"
         .IOSTANDARD(iostd), // Specify the I/O standard
         .SLEW(slew) // Specify the output slew rate
      ) IOBUF_clk_inst (
@@ -502,7 +502,7 @@ my_fifo #(.width(9)) uart_rx_fifo (
         begin
          IOBUF #(
            .DRIVE(iodrv), // Specify the output drive strength
-            .IBUF_LOW_PWR("FALSE"),  // Low Power - "TRUE", High Performance = "FALSE" 
+            .IBUF_LOW_PWR("FALSE"),  // Low Power - "TRUE", High Performance = "FALSE"
             .IOSTANDARD(iostd), // Specify the I/O standard
             .SLEW(slew) // Specify the output slew rate
         ) IOBUF_dat_inst (
@@ -513,18 +513,18 @@ my_fifo #(.width(9)) uart_rx_fifo (
         );
         rx_delay dat_rx_dly(
             .clk(clk_200MHz),
-            .in(sd_dat_to_host[sd_dat_ix]),             
+            .in(sd_dat_to_host[sd_dat_ix]),
             .maj(sd_dat_to_host_maj[sd_dat_ix]));
         end
-        
-   endgenerate					
-				   
+
+   endgenerate
+
 my_fifo #(.width(36)) tx_fifo (
   .rd_clk(~sd_clk_o),      // input wire read clk
   .wr_clk(~msoc_clk),      // input wire write clk
   .rst(data_rst),      // input wire rst
   .din({dummy[3:0],core_lsu_wdata}),      // input wire [31 : 0] din
-  .wr_en(core_lsu_req&core_lsu_we&one_hot_data_addr[5]),  // input wire wr_en
+  .wr_en(we_d&one_hot_data_addr[5]),  // input wire wr_en
   .rd_en(tx_rd_fifo),  // input wire rd_en
   .dout({dummy[7:4],data_out_tx_fifo}),    // output wire [31 : 0] dout
   .rdcount(tx_rdcount),         // 12-bit output: Read count
@@ -542,7 +542,7 @@ my_fifo #(.width(36)) rx_fifo (
   .rst(data_rst),      // input wire rst
   .din({dummy[11:8],data_in_rx_fifo}),      // input wire [31 : 0] din
   .wr_en(rx_wr_fifo),  // input wire wr_en
-  .rd_en(core_lsu_req&core_lsu_we&one_hot_data_addr[4]),  // input wire rd_en
+  .rd_en(we_d&one_hot_data_addr[4]),  // input wire rd_en
   .dout({dummy[15:12],one_hot_rdata[4]}),    // output wire [31 : 0] dout
   .rdcount(rx_rdcount),         // 12-bit output: Read count
   .rderr(rx_rderr),             // 1-bit output: Read error
@@ -560,10 +560,10 @@ my_fifo #(.width(36)) rx_fifo (
    logic [47:0] 	sd_cmd_packet, sd_cmd_packet_reg;
    logic [15:0] 	sd_transf_cnt, sd_transf_cnt_reg;
    logic            sd_detect_reg;
-   
+
    wire [31:0]  rx_fifo_status = {rx_almostfull,rx_full,rx_rderr,rx_wrerr,rx_rdcount,rx_wrcount};
    wire [31:0]  tx_fifo_status = {tx_almostfull,tx_full,tx_rderr,tx_wrerr,tx_rdcount,tx_wrcount};
-   	
+
    always @(posedge msoc_clk)
      begin
      sd_status_reg = sd_status;
@@ -571,7 +571,7 @@ my_fifo #(.width(36)) rx_fifo (
      sd_cmd_wait_reg = sd_cmd_wait;
      sd_data_wait_reg = sd_data_wait;
      sd_cmd_packet_reg = sd_cmd_packet;
-     sd_transf_cnt_reg = sd_transf_cnt;	
+     sd_transf_cnt_reg = sd_transf_cnt;
      case(core_lsu_addr[6:2])
        0: sd_cmd_resp_sel = sd_cmd_response_reg[38:7];
        1: sd_cmd_resp_sel = sd_cmd_response_reg[70:39];
@@ -580,14 +580,14 @@ my_fifo #(.width(36)) rx_fifo (
        4: sd_cmd_resp_sel = sd_cmd_wait_reg;
        5: sd_cmd_resp_sel = sd_status_reg;
        6: sd_cmd_resp_sel = sd_cmd_packet_reg[31:0];
-       7: sd_cmd_resp_sel = sd_cmd_packet_reg[47:32];       
+       7: sd_cmd_resp_sel = sd_cmd_packet_reg[47:32];
        8: sd_cmd_resp_sel = sd_data_wait_reg;
        9: sd_cmd_resp_sel = sd_transf_cnt_reg;
       10: sd_cmd_resp_sel = rx_fifo_status;
       11: sd_cmd_resp_sel = tx_fifo_status;
       12: sd_cmd_resp_sel = sd_detect_reg;
       15: sd_cmd_resp_sel = {sd_clk_locked,sd_clk_drdy,sd_clk_dout};
- 	  16: sd_cmd_resp_sel = sd_align_reg;
+      16: sd_cmd_resp_sel = sd_align_reg;
       17: sd_cmd_resp_sel = sd_clk_din;
       18: sd_cmd_resp_sel = sd_cmd_arg_reg;
       19: sd_cmd_resp_sel = sd_cmd_i_reg;
@@ -601,7 +601,7 @@ my_fifo #(.width(36)) rx_fifo (
      default: sd_cmd_resp_sel = 32'HDEADBEEF;
      endcase // case (core_lsu_addr[6:2])
      end
-   
+
    assign sd_status[3:0] = {tx_full,tx_empty,rx_full,rx_empty};
 
    assign one_hot_rdata[5] = sd_status_reg; // legacy setting
@@ -661,7 +661,7 @@ sd_top sdtop(
     .crc_actual_o(sd_cmd_response[6:0]),
     .sd_rd_o(tx_rd_fifo),
     .sd_we_o(rx_wr_fifo),
-    .sd_data_o(data_in_rx_fifo),    
+    .sd_data_o(data_in_rx_fifo),
     .sd_dat_to_mem(sd_dat_to_mem),
     .sd_cmd_to_mem(sd_cmd_to_mem),
     .sd_dat_oe(sd_dat_oe),


### PR DESCRIPTION
Removed code coremem due to unreached states (WRITE_DATA, WRITE_ADDR) because of constant assignment of aw_ready_i, ar_ready_i and w_ready_i. The states could further reduced from READ_WAIT, WRITE_WAIT to WAIT but I left it that way because I think code is more readable.

I will need to test the changes in an Arty board.